### PR TITLE
Correct chmod commands in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -138,6 +138,7 @@ By default td-agent will run as the td-agent user however the JFrog logs folder 
 ``` 
 usermod -a -G artifactory td-agent
 chmod 0770 /opt/jfrog/artifactory/var/log
+chmod 0640 /opt/jfrog/artifactory/var/log/*.log
 ```
 
 * Fix the group and file permissions issue in Xray as root:
@@ -145,6 +146,7 @@ chmod 0770 /opt/jfrog/artifactory/var/log
 ``` 
 usermod -a -G xray td-agent
 chmod 0770 /opt/jfrog/xray/var/log
+chmod 0640 /opt/jfrog/xray/var/log/*.log
 ```
 
 * Run td-agent and check it's status

--- a/README.md
+++ b/README.md
@@ -137,14 +137,14 @@ By default td-agent will run as the td-agent user however the JFrog logs folder 
 
 ``` 
 usermod -a -G artifactory td-agent
-chmod 0770 /opt/jfrog/artifactory/var/log/*
+chmod 0770 /opt/jfrog/artifactory/var/log
 ```
 
 * Fix the group and file permissions issue in Xray as root:
 
 ``` 
 usermod -a -G xray td-agent
-chmod 0770 /opt/jfrog/xray/var/log/*
+chmod 0770 /opt/jfrog/xray/var/log
 ```
 
 * Run td-agent and check it's status


### PR DESCRIPTION
0770 permissions need to be set on the application log directory itself, not on its contents. As documented, the td-agent user can't create the .pos files in the directory. It's also undesirable to give the td-agent user write permissions to the log files; it should be read-only which the default 640 permissions on *.log already provide.