### PR TITLE
Correct the timestamp_format for Xray router-request.log

### DIFF
--- a/log-vendors/datadog/fluent.conf.xray
+++ b/log-vendors/datadog/fluent.conf.xray
@@ -70,7 +70,7 @@
   <parse>
     @type json
     time_key time
-    time_format %Y-%m-%dT%H:%M:%SZ
+    time_format %Y-%m-%dT%H:%M:%S%:z
   </parse>
 </source>
 <source>

--- a/log-vendors/elastic-fluentd-kibana/fluent.conf.xray
+++ b/log-vendors/elastic-fluentd-kibana/fluent.conf.xray
@@ -70,7 +70,7 @@
   <parse>
     @type json
     time_key time
-    time_format %Y-%m-%dT%H:%M:%SZ
+    time_format %Y-%m-%dT%H:%M:%S%:z
   </parse>
 </source>
 <source>

--- a/log-vendors/prometheus-fluentd-grafana/fluent.conf.xray
+++ b/log-vendors/prometheus-fluentd-grafana/fluent.conf.xray
@@ -109,7 +109,7 @@
   <parse>
     @type json
     time_key time
-    time_format %Y-%m-%dT%H:%M:%SZ
+    time_format %Y-%m-%dT%H:%M:%S%:z
   </parse>
 </source>
 <source>

--- a/log-vendors/splunk/fluent.conf.xray
+++ b/log-vendors/splunk/fluent.conf.xray
@@ -70,7 +70,7 @@
   <parse>
     @type json
     time_key time
-    time_format %Y-%m-%dT%H:%M:%SZ
+    time_format %Y-%m-%dT%H:%M:%S%:z
   </parse>
 </source>
 <source>


### PR DESCRIPTION
This was fixed for Artifactory in #6, same is needed for Xray.

Fixes #29