### PR TITLE
Fluentd install comments and potential improvements 

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,7 +93,7 @@ Recommended install is through fluentd's native OS based package installs:
 | MacOS/Darwin  | DMG             | https://docs.fluentd.org/installation/install-by-dmg |
 | Windows       | MSI             | https://docs.fluentd.org/installation/install-by-msi |
 
-Alternatively, it's also possible to use the shell script to install Fluentd as service (td-agent4):
+Alternatively, it's also possible to use the shell script to install Fluentd as service (td-agent4, root access required):
 
 | OS            | Package Manager | Link |
 |---------------|-----------------|------|
@@ -249,7 +249,7 @@ If you wish to only run td-agent against a test configuration file you can also 
 td-agent -c fluentd.conf
 ```
 
-Once td-agent has been installed on an Artifactory or Xray node you will also need to install the relevant plugin if you are using Splunk or Datadog:
+If Fluentd was installed with [fluentd-agent-installer.sh](https://raw.githubusercontent.com/jfrog/log-analytics/master/fluentd-installer/scripts/linux/fluentd-agent-installer.sh) this step can be skipped. Once td-agent has been installed on an Artifactory or Xray node you will also need to install the relevant plugin if you are using Splunk or Datadog:
 
 Splunk:
 ```
@@ -313,7 +313,7 @@ If you are running on RT 6.x you will need to ensure the ARTIFACTORY_HOME enviro
 
 ### Running as a service
 
-By default td-agent will run as the td-agent user however the JFrog logs folder only has file permissions for the artifactory or xray user.
+If Fluentd was installed with [fluentd-agent-installer.sh](https://raw.githubusercontent.com/jfrog/log-analytics/master/fluentd-installer/scripts/linux/fluentd-agent-installer.sh) this step can be omitted. By default td-agent will run as the td-agent user however the JFrog logs folder only has file permissions for the artifactory or xray user.
 
 * Fix the group and file permissions issue in Artifactory as root:
 

--- a/README.md
+++ b/README.md
@@ -93,15 +93,15 @@ Recommended install is through fluentd's native OS based package installs:
 | MacOS/Darwin  | DMG             | https://docs.fluentd.org/installation/install-by-dmg |
 | Windows       | MSI             | https://docs.fluentd.org/installation/install-by-msi |
 
-Alternatively, it's also possible to use the shell script to install Fluentd as service (experimental). The script installs td-agent 4 and requires sudo rights. 
+__[EXPERIMENTAL]__ Alternatively, it's also possible to use the shell script to install Fluentd as service (experimental). The script installs td-agent 4 and requires sudo rights. 
 The script performs the following tasks:
 - Downloads the github repo and all dependencies [optional]
 - Checks if the Fluentd requirements are met and updates the OS if needed [optional]
-- Installs Fluentd as a service depending on Linux distro (Centos and Amazon is supported, more to come).
+- Installs/Updates Fluentd as a service depending on Linux distro (Centos and Amazon is supported, more to come).
 - Updates the log files/folders permissions [optional].
-- Install Fluentd plugins (Splunk, Datadog, Elastic)[optional].
-- Starts and enables the td service [optional] // TODO
-- Suggests next step based (link to the fluentd configuration steps based on the installed plugin) // TODO
+- Installs Fluentd plugins (Splunk, Datadog, Elastic)[optional].
+- Starts and enables the td service [optional]
+- Suggests next step (link to the fluentd configuration steps based on the installed plugin) // TODO
 
 | OS            | Package Manager | Link |
 |---------------|-----------------|------|
@@ -322,8 +322,8 @@ If you are running on RT 6.x you will need to ensure the ARTIFACTORY_HOME enviro
 Additional information how to configure fluentd conf:
 
 - [Splunk](https://github.com/jfrog/log-analytics-splunk)
-- [Elastic](https://github.com/jfrog/log-analytics-elastic)
 - [Datadog](https://github.com/jfrog/log-analytics-datadog)
+- [Elastic](https://github.com/jfrog/log-analytics-elastic)
 
 ### Running as a service
 

--- a/README.md
+++ b/README.md
@@ -100,8 +100,8 @@ The script performs the following tasks:
 - Installs/Updates Fluentd as a service depending on Linux distro (Centos and Amazon is supported, more to come).
 - Updates the log files/folders permissions [optional].
 - Installs Fluentd plugins (Splunk, Datadog, Elastic)[optional].
-- Starts and enables the td service [optional]
-- Suggests next step (link to the fluentd configuration steps based on the installed plugin) // TODO
+- Starts and enables the td service [optional].
+- Suggests next step (link to the fluentd configuration steps based on the installed plugin).
 
 | OS            | Package Manager | Link |
 |---------------|-----------------|------|

--- a/README.md
+++ b/README.md
@@ -93,7 +93,15 @@ Recommended install is through fluentd's native OS based package installs:
 | MacOS/Darwin  | DMG             | https://docs.fluentd.org/installation/install-by-dmg |
 | Windows       | MSI             | https://docs.fluentd.org/installation/install-by-msi |
 
-Alternatively, it's also possible to use the shell script to install Fluentd as service (td-agent4, root access required):
+Alternatively, it's also possible to use the shell script to install Fluentd as service (experimental). The script installs td-agent 4 and requires sudo rights. 
+The script performs the following tasks:
+- Downloads the github repo and all dependencies [optional]
+- Checks if the Fluentd requirements are met and updates the OS if needed [optional]
+- Installs Fluentd as a service depending on Linux distro (Centos and Amazon is supported, more to come).
+- Updates the log files/folders permissions [optional].
+- Install Fluentd plugins (Splunk, Datadog, Elastic)[optional].
+- Starts and enables the td service [optional] // TODO
+- Suggests next step based (link to the fluentd configuration steps based on the installed plugin) // TODO
 
 | OS            | Package Manager | Link |
 |---------------|-----------------|------|
@@ -310,6 +318,12 @@ export JF_PRODUCT_DATA_INTERNAL=/opt/jfrog/pipelines/var/
 ````
 
 If you are running on RT 6.x you will need to ensure the ARTIFACTORY_HOME environment variable is set instead.
+
+Additional information how to configure fluentd conf:
+
+- [Splunk](https://github.com/jfrog/log-analytics-splunk)
+- [Elastic](https://github.com/jfrog/log-analytics-elastic)
+- [Datadog](https://github.com/jfrog/log-analytics-datadog)
 
 ### Running as a service
 

--- a/README.md
+++ b/README.md
@@ -39,10 +39,7 @@ Fluentd is a required component to use this integration.
 
 Fluentd has an logger agent called td-agent which will be required to be installed into each node you wish to monitor logs on.
 
-For more details on how to install Fluentd into your environment please visit:
-
-[Fluentd installation guide](https://docs.fluentd.org/installation)
-
+For more details on how to install Fluentd into your environment please visit: [Fluentd installation guide] (https://docs.fluentd.org/installation) or read the steps provided in this document.
 #### JFrog Installation Configurations
 
 Due to the nature of customer installations varying we cannot account for all possible installations however to ensure our integration works with your installation please review:
@@ -95,6 +92,12 @@ Recommended install is through fluentd's native OS based package installs:
 | Debian/Ubuntu | APT             | https://docs.fluentd.org/installation/install-by-deb |
 | MacOS/Darwin  | DMG             | https://docs.fluentd.org/installation/install-by-dmg |
 | Windows       | MSI             | https://docs.fluentd.org/installation/install-by-msi |
+
+Alternatively, it's also possible to use the shell script to install Fluentd as service (td-agent4):
+
+| OS            | Package Manager | Link |
+|---------------|-----------------|------|
+| Linux (x86_64) Centos/Amazon| N/A             | https://raw.githubusercontent.com/jfrog/log-analytics/master/fluentd-installer/scripts/linux/fluentd-agent-installer.sh |
 
 User installs can utilize the zip installer for Linux
 

--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ export JF_PRODUCT_DATA_INTERNAL=/var/opt/jfrog/xray/
 ````
 
 ````text
-Mision Control:
+Mission Control:
 export JF_PRODUCT_DATA_INTERNAL=/var/opt/jfrog/mc/
 ````
 

--- a/fluentd-installer/scripts/linux/fluentd-agent-installer.sh
+++ b/fluentd-installer/scripts/linux/fluentd-agent-installer.sh
@@ -133,7 +133,7 @@ if [ "$linux_distro" == "centos" ]; then
 elif [ "$linux_distro" == "amazon" ]; then
   echo "Amazon Linux detected. Installing td-agent 4..."
   {
-    curl -L https://toolbelt.treasuredata.com/sh/install-redhat-td-agent4.sh | sh
+    curl -L https://toolbelt.treasuredata.com/sh/install-amazon2-td-agent4.sh | sh
   } || {
     echo Error, td agent 4 installation failed
     exit 0

--- a/fluentd-installer/scripts/linux/fluentd-agent-installer.sh
+++ b/fluentd-installer/scripts/linux/fluentd-agent-installer.sh
@@ -174,6 +174,12 @@ if [ "$install_plugins" == true ]; then
       help_link=https://github.com/jfrog/log-analytics-elastic
       break
       ;;
+    [prometheus]*)
+      echo Installing fluent-plugin-prometheus...
+      sudo td-agent-gem install fluent-plugin-prometheus
+      help_link=https://github.com/jfrog/log-analytics-prometheus
+      break
+      ;;
     *) echo "Please answer Splunk, Datadog or Elastic." ;;
     esac
   done
@@ -197,7 +203,7 @@ fi
 
 # Fin!
 # TODO Better error handling needed so we're 100% sure that it's actually successful.
-echo ===================================================================================================================
+echo ===============================================================
 echo Fluentd service was successfully installed!
 echo The Fluentd configuration might require addition steps, more info: $config_link
-echo ===================================================================================================================
+echo ===============================================================

--- a/fluentd-installer/scripts/linux/fluentd-agent-installer.sh
+++ b/fluentd-installer/scripts/linux/fluentd-agent-installer.sh
@@ -1,0 +1,153 @@
+#!/bin/sh
+
+## Util functions
+# Yes/No Input
+question() {
+  question_text=$1
+  answer=null
+  while true; do
+    read -p "$question_text" yesno
+    case $yesno in
+    [Yy]*)
+      answer=true
+      break
+      ;;
+    [Nn]*)
+      answer=false
+      break
+      ;;
+    *) echo "Please answer yes or no." ;;
+    esac
+  done
+  echo $answer
+}
+
+# Modify conf file
+modify_conf_file() {
+  now_date=$(date +"%m_%d_%Y_%H_%M_%S")
+  backup_postfix="_la_backup_$now_date"
+  # backup modifying file first
+  file_path=$1
+  file_path_backup="${file_path}${backup_postfix}"
+  conf_content=$2
+  sudo cp "${file_path}" "${file_path_backup}"
+  echo "Modifying ${file_path}..."
+  echo "$conf_content" | sudo tee -a "$file_path"
+  echo "File ${file_path} modified and the original content backed up to ${file_path_backup}"
+}
+
+update_permissions() {
+  group=$1
+  default_path=$2
+  update_perm=$(question "Would you like to update the $group log permissions? [y/n]");
+  if [ "$update_perm" == true ]; then
+    {
+      read -p "Please provide $group path [default: ${default_path}]:" product_path
+      if [ -z "$var" ]; then
+        product_path=$default_path
+      fi
+      sudo usermod -a -G "$group" td-agent
+      echo Updating ${product_path}/log ...
+      sudo sh -c 'chmod 0770 '"$product_path"'/log'
+      sudo sh -c 'chmod 0640 '"$product_path"'/log/*.log'
+    } || {
+      echo Error. The permissions update for "$group" wasn\'t successful.
+    }
+  fi
+}
+
+## Fluentd Install Script
+echo ==============================================================
+echo This script installs Fluentd td-agent4 service
+echo and clones Jfrog Log Analitics GitHub repository \(optional\).
+echo ==============================================================
+
+## Clone github repository?
+clone_repo=$(question "Would you like to clone JFrog log analytics GitHub repository? [y/n]")
+if [ "$clone_repo" == true ]; then
+  {
+    repo_url="https://github.com/jfrog/log-analytics.git"
+    echo Cloning repository ${repo_url}
+    git clone $repo_url --recursive
+    echo Cloning dependencies...
+    cd log-analytics
+    git submodule foreach git checkout master
+    git submodule foreach git pull origin master
+  } || {
+    echo Error while cloning the repository.
+    exit 0
+  }
+fi
+
+# Check the Fluentd requirements (file descriptors, etc)
+ulimit_output=$(ulimit -n)
+if [ $ulimit_output -lt 65536 ]; then
+  # Update the file descriptors limit per process and 'high load environments' if needed
+  echo "Fluentd requires higher limit of the file descriptors per process and optimize the network kernel parameters. More info: https://docs.fluentd.org/installation/before-install"
+  update_limit=$(question "Would you like to change the mentioned configuration (current: $(ulimit -n), minimum: 65536)? [y/n]")
+  if [ $update_limit == true ]; then
+    limit_conf_file_path=/etc/security/limits.conf
+    limit_config="
+# Added by JFrog log-analytics install script
+root soft nofile 65536
+root hard nofile 65536
+* soft nofile 65536
+* hard nofile 65536"
+    modify_conf_file $limit_conf_file_path "$limit_config"
+    nkp_path_file=/etc/sysctl.conf
+    nkp_config="
+# Added by JFrog log-analytics install script
+net.core.somaxconn = 1024
+net.core.netdev_max_backlog = 5000
+net.core.rmem_max = 16777216
+net.core.wmem_max = 16777216
+net.ipv4.tcp_wmem = 4096 12582912 16777216
+net.ipv4.tcp_rmem = 4096 12582912 16777216
+net.ipv4.tcp_max_syn_backlog = 8096
+net.ipv4.tcp_slow_start_after_idle = 0
+net.ipv4.tcp_tw_reuse = 1
+net.ipv4.ip_local_port_range = 10240 65535"
+    modify_conf_file $nkp_path_file "$nkp_config"
+  fi
+fi
+
+# Fetch and installing td-agent4 (for now only Centos and Amazon distros)
+linux_distro=$(cat /etc/*-release | tr [:upper:] [:lower:] | grep -Poi '(centos|ubuntu|red hat|amazon|debian)' | uniq)
+if [ "$linux_distro" == "centos" ]; then
+  echo "Centos detected. Installing td-agent 4..."
+  {
+    curl -L https://toolbelt.treasuredata.com/sh/install-redhat-td-agent4.sh | sh
+  } || {
+    echo Error, td agent 4 installation failed
+    exit 0
+  }
+elif [ "$linux_distro" == "amazon" ]; then
+  echo "Amazon Linux detected. Installing td-agent 4..."
+  {
+    curl -L https://toolbelt.treasuredata.com/sh/install-redhat-td-agent4.sh | sh
+  } || {
+    echo Error, td agent 4 installation failed
+    exit 0
+  }
+else
+  echo "Unsupported (${linux_distro}) Linux distro."
+fi
+
+# Update the log permissions/users artifactory
+update_permissions "artifactory" "/var/opt/jfrog/artifactory"
+
+# Update the log permissions/users xray
+update_permissions "xray" "/var/opt/jfrog/xray"
+
+# Start td service
+echo Starting td-agent service...
+if [[ $(systemctl) =~ -\.mount ]]; then
+  sudo systemctl start td-agent.service
+  sudo systemctl status td-agent.service
+else
+  sudo /etc/init.d/td-agent start
+  sudo /etc/init.d/td-agent status
+fi
+
+# Summary
+echo DONE!


### PR DESCRIPTION
This pull request is meant to improve the log analytics installation experience. The changes in the PR should be treated as suggestions as I’m not very familiar with the log-analytics functionality. The PR contains the following changes:

1. Interactive Fluentd installer with the following functionality:
    - Downloads the github repo and all dependencies [optional]
    - Checks if the Fluentd requirements are met and updates the OS if needed [optional]
     - Installs/Updates Fluentd as a service depending on Linux distro (Centos and Amazon is supported, more to come).
     - Updates the log files/folders permissions [optional].
     - Installs Fluentd plugins (Splunk, Datadog, Elastic, etc)[optional].
     - Starts and enables the td service [optional].
     - Suggests next step (link to the fluentd configuration steps based on the installed plugin).

2. Changes in the log-analytics README.md.
3. General comments not directly related/included to the PR changes.

     -  [Splunk repo] - https://github.com/jfrog/log-analytics-splunk README.md
                   - “Configure HEC to accept data” - this steps should mention to write down the HEC port used later the steps (default is 8088)
          - “Configure new HEC token” - this doesn't sound right?: 
               > #5 Enter a "Name" in the textbox

          - “Splunk App” - JFrog app can be installed directly from the Splunk store instead of a file (app) that needs to be uploaded/installed later so some steps could be removed.


     - [Elastic] - https://github.com/jfrog/log-analytics-elastic
           - The fluentd steps in README.md seem to be unnecessary since the same info is available at the log-analytics repo (probably hard to maintain the some content in multiple locations).
     -  [Prometheus] - https://github.com/jfrog/log-analytics-prometheus
          - IMHO this one is the most challenging
          - It’d be great if we provide more information about the k8s/yaml files and their purpose.
          - I tried to set up the environment using minikube/helm but eventually gave up (some of the yaml files were throwing errors (e.g Unexpected args:...  + LB service is not supported in minikube).
     - General comments that apply to all README.md/steps
          - I'd be great if we could provide info on how to troubleshoot in case of problems, e.g where to find relevant logs, etc.
          -  In every section related to fluentd.conf file we should remind that JF_PRODUCT_DATA_INTERNAL needs to be specified, otherwise fluentd won't work. 
          - It’d be worth mentioning it where the fluentd conf file is located (e.g for td-service service, etc).

Please let me know if you have any questions.






